### PR TITLE
0.0.1a3 - Second pass on fixing #2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG : xflFastR-py
 
+## 0.0.1a3 - Second pass on fixing #2
+
+- Attempted a fix on a bug where the following error was raised when installing:
+  `ERROR: No matching distribution found for urllib [end of output]`
+
 ## 0.0.1a2 - First pass on fixing #2
 
 - Attempted a fix on a bug where the following error was raised when installing:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools","wheel","pyarrow","pandas","tqdm","urllib","requests","lxml"]
+requires = ["setuptools","wheel","pyarrow","pandas","tqdm","requests","lxml"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
- Attempted a fix on a bug where the following error was raised when installing: `ERROR: No matching distribution found for urllib [end of output]`